### PR TITLE
[feat] add validation for in a view exist

### DIFF
--- a/packages/language-server/validators/validate-document.js
+++ b/packages/language-server/validators/validate-document.js
@@ -4,6 +4,7 @@ const validatePageExist = require('./validate-page-exist')
 const validateDataTypes = require('./validate-data-type')
 const validatePolicyExist = require('./validate-policy-exist')
 const validateModelAttributeExist = require('./validate-model-attribute-exist')
+const validateViewExist = require('./validate-view-exist')
 module.exports = function validateDocument(connection, document, typeMap) {
   const diagnostics = []
 
@@ -16,13 +17,15 @@ module.exports = function validateDocument(connection, document, typeMap) {
     document,
     typeMap
   )
+  const viewDiagnostics = validateViewExist(document, typeMap)
   diagnostics.push(
     ...modelDiagnostics,
     ...actionDiagnostics,
     ...pageDiagnostics,
     ...dataTypeDiagnostics,
     ...policyDiagnostics,
-    ...modelAttributeDiagnostics
+    ...modelAttributeDiagnostics,
+    ...viewDiagnostics
   )
 
   connection.sendDiagnostics({ uri: document.uri, diagnostics })

--- a/packages/language-server/validators/validate-view-exist.js
+++ b/packages/language-server/validators/validate-view-exist.js
@@ -1,0 +1,86 @@
+const lsp = require('vscode-languageserver/node')
+
+module.exports = function validateViewExist(document, typeMap) {
+  const diagnostics = []
+
+  // Only check routes.js and actions (api/controllers)
+  const isRoutes = document.uri.endsWith('routes.js')
+  const isAction = document.uri.includes('/api/controllers/')
+  if (!isRoutes && !isAction) return diagnostics
+
+  // Extract { view: '...' } in routes.js
+  if (isRoutes) {
+    const views = extractViewReferences(document)
+    for (const { view, range } of views) {
+      if (!typeMap.views?.[view]) {
+        diagnostics.push(
+          lsp.Diagnostic.create(
+            range,
+            `View '${view}' not found. Make sure it exists in your /views directory.`,
+            lsp.DiagnosticSeverity.Error,
+            'sails-lsp'
+          )
+        )
+      }
+    }
+  }
+
+  // Extract viewTemplatePath: '...' in actions
+  if (isAction) {
+    const exits = extractViewTemplatePathReferences(document)
+    for (const { view, range } of exits) {
+      if (!typeMap.views?.[view]) {
+        diagnostics.push(
+          lsp.Diagnostic.create(
+            range,
+            `View '${view}' not found. Make sure it exists in your /views directory.`,
+            lsp.DiagnosticSeverity.Error,
+            'sails-lsp'
+          )
+        )
+      }
+    }
+  }
+
+  return diagnostics
+}
+
+function extractViewReferences(document) {
+  const text = document.getText()
+  const regex = /view\s*:\s*['"]([^'"]+)['"]/g
+  const views = []
+  let match
+  while ((match = regex.exec(text)) !== null) {
+    const view = match[1]
+    const viewStart = match.index + match[0].indexOf(view)
+    const viewEnd = viewStart + view.length
+    views.push({
+      view,
+      range: lsp.Range.create(
+        document.positionAt(viewStart),
+        document.positionAt(viewEnd)
+      )
+    })
+  }
+  return views
+}
+
+function extractViewTemplatePathReferences(document) {
+  const text = document.getText()
+  const regex = /viewTemplatePath\s*:\s*['"]([^'"]+)['"]/g
+  const views = []
+  let match
+  while ((match = regex.exec(text)) !== null) {
+    const view = match[1]
+    const viewStart = match.index + match[0].indexOf(view)
+    const viewEnd = viewStart + view.length
+    views.push({
+      view,
+      range: lsp.Range.create(
+        document.positionAt(viewStart),
+        document.positionAt(viewEnd)
+      )
+    })
+  }
+  return views
+}


### PR DESCRIPTION
Resolves #24 

This pull request introduces a new validation function, `validateViewExist`, to ensure that views referenced in `routes.js` and controller actions exist in the `/views` directory. The changes are integrated into the `validateDocument` pipeline and include the implementation of helper functions for extracting view references. Below are the key changes grouped by theme:

### Integration of `validateViewExist` into the validation pipeline:
* Added `validateViewExist` to the list of imported validators in `packages/language-server/validators/validate-document.js`.
* Modified the `validateDocument` function to invoke `validateViewExist` and include its diagnostics in the overall diagnostics array.

### Implementation of `validateViewExist`:
* Created a new file, `packages/language-server/validators/validate-view-exist.js`, which defines the `validateViewExist` function. This function checks for missing views in `routes.js` and controller actions, generating diagnostics for unresolved view references.
* Added helper functions `extractViewReferences` and `extractViewTemplatePathReferences` to parse view references from `routes.js` and controller actions, respectively. These functions use regular expressions to locate and extract view paths along with their corresponding ranges.