### PR TITLE
feat(language-server): add helpers completion functionality

### DIFF
--- a/packages/language-server/completions/helpers-completion.js
+++ b/packages/language-server/completions/helpers-completion.js
@@ -1,0 +1,69 @@
+const { CompletionItemKind } = require('vscode-languageserver/node')
+
+// Convert kebab-case to camelCase (e.g., 'send-email' -> 'sendEmail')
+function kebabToCamel(str) {
+  return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+}
+
+// Get the helper path context from the line, e.g. sails.helpers.email.
+function getHelpersContext(line) {
+  const match = line.match(/sails\.helpers((?:\.[a-zA-Z0-9_]+)*)\.$/)
+  if (!match) return []
+  // e.g. '.email.foo.' => ['email', 'foo']
+  return match[1] ? match[1].split('.').filter(Boolean) : []
+}
+
+module.exports = function helpersCompletion(document, position, typeMap) {
+  const line = document.getText({
+    start: { line: position.line, character: 0 },
+    end: position
+  })
+  const helpers = typeMap.helpers || {}
+  const context = getHelpersContext(line.trim())
+  if (!line.trim().includes('sails.helpers.')) return []
+
+  // Build a tree of helpers from the flat keys
+  const tree = {}
+  for (const key of Object.keys(helpers)) {
+    const parts = key.split('/')
+    let node = tree
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i]
+      if (!node[part])
+        node[part] =
+          i === parts.length - 1 ? { __isHelper: true, __key: key } : {}
+      node = node[part]
+    }
+  }
+
+  // Traverse the tree according to the context
+  let node = tree
+  for (const part of context) {
+    if (!node[part]) return []
+    node = node[part]
+  }
+
+  // If at a namespace, suggest children (namespaces or helpers)
+  return Object.entries(node)
+    .filter(([k]) => !k.startsWith('__'))
+    .map(([k, v]) => {
+      if (v.__isHelper) {
+        // Only camelCase the last segment
+        return {
+          label: kebabToCamel(k),
+          kind: CompletionItemKind.Method,
+          detail: `Helper: ${v.__key}`,
+          documentation: helpers[v.__key].path || '',
+          insertText: kebabToCamel(k)
+        }
+      } else {
+        // Namespace/folder
+        return {
+          label: k,
+          kind: CompletionItemKind.Module,
+          detail: 'Helper namespace',
+          insertText: k + '.'
+        }
+      }
+    })
+}

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -24,6 +24,7 @@ const policiesCompletion = require('./completions/policies-completion')
 const viewsCompletion = require('./completions/views-completion')
 const modelMethodsCompletion = require('./completions/model-methods-completion')
 const modelAttributesCompletion = require('./completions/model-attributes-completion')
+const helpersCompletion = require('./completions/helpers-completion')
 const connection = lsp.createConnection(lsp.ProposedFeatures.all)
 const documents = new lsp.TextDocuments(TextDocument)
 
@@ -103,54 +104,30 @@ connection.onDefinition(async (params) => {
 
 connection.onCompletion(async (params) => {
   const document = documents.get(params.textDocument.uri)
-  if (!document) {
-    return null
-  }
-  const [
-    actionCompletion,
-    dataTypeCompletion,
-    modelAttributePropCompletion,
-    inputPropCompletion,
-    inertiaPageCompletion,
-    modelCompletion,
-    policyCompletion,
-    viewCompletion,
-    modelMethodCompletion,
-    modelAttributeCompletion
-  ] = await Promise.all([
-    actionsCompletion(document, params.position, typeMap),
-    dataTypesCompletion(document, params.position, typeMap),
-    modelAttributePropsCompletion(document, params.position, typeMap),
-    inputPropsCompletion(document, params.position, typeMap),
-    inertiaPagesCompletion(document, params.position, typeMap),
-    modelsCompletion(document, params.position, typeMap),
-    policiesCompletion(document, params.position, typeMap),
-    viewsCompletion(document, params.position, typeMap),
-    modelMethodsCompletion(document, params.position, typeMap),
-    modelAttributesCompletion(document, params.position, typeMap)
-  ])
+  if (!document) return []
+  const position = params.position
 
-  const completions = [
-    ...actionCompletion,
-    ...dataTypeCompletion,
-    ...modelAttributePropCompletion,
-    ...inputPropCompletion,
-    ...inertiaPageCompletion,
-    ...modelCompletion,
-    ...policyCompletion,
-    ...viewCompletion,
-    ...modelMethodCompletion,
-    ...modelAttributeCompletion
-  ].filter(Boolean)
-
-  if (completions) {
-    return {
-      isIncomplete: false,
-      items: completions
-    }
+  // Check if helpersCompletion is triggered and return only those if so
+  const helpers = helpersCompletion(document, position, typeMap) || []
+  if (helpers.length > 0) {
+    return helpers
   }
 
-  return null
+  // Otherwise, compose completions from all other providers
+  let completions = []
+  completions = completions.concat(
+    actionsCompletion(document, position, typeMap) || [],
+    dataTypesCompletion(document, position, typeMap) || [],
+    modelAttributePropsCompletion(document, position, typeMap) || [],
+    inputPropsCompletion(document, position, typeMap) || [],
+    inertiaPagesCompletion(document, position, typeMap) || [],
+    modelsCompletion(document, position, typeMap) || [],
+    policiesCompletion(document, position, typeMap) || [],
+    viewsCompletion(document, position, typeMap) || [],
+    modelMethodsCompletion(document, position, typeMap) || [],
+    modelAttributesCompletion(document, position, typeMap) || []
+  )
+  return completions
 })
 
 documents.listen(connection)


### PR DESCRIPTION
Fixes #26 
This pull request introduces a new helper completion feature to the language server, refactors the completion logic for efficiency, and integrates the helper completions into the main completion handler. The changes enhance the developer experience by providing more context-aware suggestions for `sails.helpers`.

### Addition of helper completions:

* [`packages/language-server/completions/helpers-completion.js`](diffhunk://#diff-5021212c924d45839930239360e31e846ce3ebdf3b454b2cefb95d816a070898R1-R69): Added a new helper completion module to provide context-aware suggestions for `sails.helpers`. This includes converting `kebab-case` to `camelCase`, building a hierarchical tree from helper keys, and returning appropriate completions for helper methods and namespaces.

### Integration into the language server:

* [`packages/language-server/index.js`](diffhunk://#diff-a6a1c200ec5145d7b787aa390de8241da13470bf298546f333d6625dfeddce4eR27): Imported the new `helpersCompletion` module and integrated it into the completion handler. The handler now prioritizes helper completions when triggered by `sails.helpers`, improving performance and specificity. [[1]](diffhunk://#diff-a6a1c200ec5145d7b787aa390de8241da13470bf298546f333d6625dfeddce4eR27) [[2]](diffhunk://#diff-a6a1c200ec5145d7b787aa390de8241da13470bf298546f333d6625dfeddce4eL106-R130)