### PR TITLE
feat: add missing Waterline query predicates (or, and, not)

### DIFF
--- a/packages/language-server/validators/validate-model-attribute-exist.js
+++ b/packages/language-server/validators/validate-model-attribute-exist.js
@@ -282,7 +282,10 @@ module.exports = function validateModelAttributeExist(document, typeMap) {
                 'min',
                 'max',
                 'distinct',
-                'meta'
+                'meta',
+                'or',
+                'and',
+                'not'
               ]
               // For non-create methods, validate all top-level keys except query option keys
               if (


### PR DESCRIPTION
Closes #50

## Description

This PR fixes validation errors for valid Waterline query predicates (, , ) that were incorrectly being flagged as invalid model attributes.

## Problem

The language server was throwing validation errors like:


But , , and  are valid Waterline query predicates as documented in the [Sails.js documentation](https://sailsjs.com/documentation/concepts/models-and-orm/query-language#?or-predicate).

## Solution

Added the missing Waterline query predicates to the  array in :

-  - Waterline OR predicate
-  - Waterline AND predicate  
-  - Waterline NOT predicate

## Changes

- ✅ Added missing query predicates to  array (lines 286-288)
- ✅ Maintains existing validation logic for actual model attributes
- ✅ No breaking changes

## Testing

This change ensures that queries like the following will no longer trigger false positive validation errors:

