### PR TITLE
fix(language-server): skip redirects and external URLs in go-to action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7228,7 +7228,7 @@
     },
     "packages/language-server": {
       "name": "@sailshq/language-server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.14.1",
@@ -7261,7 +7261,7 @@
     },
     "packages/vscode": {
       "name": "sails-vscode",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"
@@ -7270,29 +7270,13 @@
         "@rsdoctor/rspack-plugin": "^0.4.1",
         "@rspack/cli": "^1.3.13",
         "@rspack/core": "^1.3.13",
-        "@sailshq/language-server": "^0.2.3",
+        "@sailshq/language-server": "^0.3.1",
         "@types/node": "^22.5.2",
         "@types/vscode": "^1.82.0",
         "@vscode/vsce": "^3.0.0"
       },
       "engines": {
         "vscode": "^1.82.0"
-      }
-    },
-    "packages/vscode/node_modules/@sailshq/language-server": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@sailshq/language-server/-/language-server-0.2.3.tgz",
-      "integrity": "sha512-q70uwL0WNMoB1VLomxZ3VkGoagJ5l2/nK5bdz1C6JjfTzzKHIZwRt0gAre8jB/5iJB3LwCcT1qtR1U/w7L38CA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.14.1",
-        "acorn-walk": "^8.3.4",
-        "vscode-languageserver": "^9.0.1",
-        "vscode-languageserver-textdocument": "^1.0.12"
-      },
-      "bin": {
-        "sails-language-server": "bin/sails-language-server.js"
       }
     }
   }

--- a/packages/language-server/SailsParser.js
+++ b/packages/language-server/SailsParser.js
@@ -66,6 +66,13 @@ class SailsParser {
     while ((match = regex.exec(content))) {
       const route = match[1]
       const actionName = match[2]
+
+      // Skip redirects and external URLs
+      // Routes that start with '/' or contain '://' are redirects, not actions
+      if (actionName.startsWith('/') || actionName.includes('://')) {
+        continue
+      }
+
       const filePath = path.join(actionsRoot, ...actionName.split('/')) + '.js'
 
       const actionInfo = await this.#parseAction(filePath)


### PR DESCRIPTION
Closes #52

## Changes

- Skip route values that start with '/' (relative redirects)
- Skip route values that contain '://' (absolute URLs)
- Prevents ENOENT errors when trying to open non-existent action files

## Problem Solved

The go-to action functionality was incorrectly treating route redirects and external URLs as action file paths, causing ENOENT errors when trying to navigate to them.

Routes like:
- 'GET /terms': '/legal/terms'
- 'GET /privacy': '/legal/privacy'
- External URLs with 'https://...'

Are now properly ignored as they are redirects, not action files that can be navigated to.