### PR TITLE
feat(validate-required-model-attribute): restrict validation to backend directories

### DIFF
--- a/packages/language-server/validators/validate-required-model-attribute.js
+++ b/packages/language-server/validators/validate-required-model-attribute.js
@@ -2,6 +2,13 @@ const lsp = require('vscode-languageserver/node')
 
 module.exports = function validateRequiredModelAttribute(document, typeMap) {
   const diagnostics = []
+  const documentUri = document.uri
+
+  // Only validate files in backend directories where models are accessible
+  if (!documentUri.includes('/api/') && !documentUri.includes('/scripts/')) {
+    return diagnostics
+  }
+
   const text = document.getText()
   const models = typeMap.models || {}
 


### PR DESCRIPTION
Resolves #89 